### PR TITLE
feat: add translate mode for raw-to-rational draft conversion

### DIFF
--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -1,7 +1,7 @@
 import { settings } from '$lib/config'
-import { anthropicPrompt } from '$lib/prompts'
+import { anthropicPrompt, translatePrompt, translateSystemContext } from '$lib/prompts'
 import type { Message, ToneType } from '$lib/types'
-import { extractReplies, parseSummaryToHumanReadable } from '$lib/utils'
+import { extractReplies, formatMessagesAsText, parseSummaryToHumanReadable } from '$lib/utils'
 import { fetchRelevantHistory } from './history'
 import { logger } from './logger'
 
@@ -76,5 +76,57 @@ export const getAnthropicReply = async (
             summary: '',
             replies: ['(AI API error. Check your key and usage.)'],
         }
+    }
+}
+
+export const translateAnthropicDraft = async (
+    messages: Message[],
+    tone: ToneType,
+    userDraft: string,
+    context: string
+): Promise<{ replies: string[] }> => {
+    const config = getConfig()
+
+    if (!config.apiKey) {
+        return { replies: ['Anthropic API key is not configured.'] }
+    }
+
+    const prompt = [
+        translateSystemContext(),
+        'Here are some text messages between my partner and I:\n' + formatMessagesAsText(messages),
+        translatePrompt(userDraft, tone, context),
+    ].join('\n\n')
+
+    const body = {
+        model: config.model,
+        max_tokens: 1024,
+        temperature: config.temperature,
+        messages: [{ role: 'user', content: prompt }],
+    }
+
+    logger.info('Sending translate request to Anthropic')
+
+    try {
+        const response = await fetch(API_URL, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'x-api-key': config.apiKey,
+                'anthropic-version': '2023-06-01',
+            },
+            body: JSON.stringify(body),
+        })
+
+        if (!response.ok) {
+            throw new Error(`Anthropic API error code ${response.status}: ${response.statusText}`)
+        }
+
+        const data = (await response.json()) as { content?: Array<{ text?: string }> }
+        const rawOutput = data.content?.[0]?.text || ''
+        const replies = extractReplies(rawOutput)
+        return { replies }
+    } catch (error) {
+        logger.error({ error }, 'Error in translateAnthropicDraft')
+        return { replies: ['(AI API error. Check your key and usage.)'] }
     }
 }

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -1,6 +1,6 @@
 import { settings } from '$lib/config'
 import { anthropicPrompt, translatePrompt, translateSystemContext } from '$lib/prompts'
-import type { Message, ToneType } from '$lib/types'
+import type { Message, ToneType, TranslateResult } from '$lib/types'
 import { extractReplies, formatMessagesAsText, parseSummaryToHumanReadable } from '$lib/utils'
 import { fetchRelevantHistory } from './history'
 import { logger } from './logger'
@@ -84,7 +84,7 @@ export const translateAnthropicDraft = async (
     tone: ToneType,
     userDraft: string,
     context: string
-): Promise<{ replies: string[] }> => {
+): Promise<TranslateResult> => {
     const config = getConfig()
 
     if (!config.apiKey) {
@@ -99,7 +99,7 @@ export const translateAnthropicDraft = async (
 
     const body = {
         model: config.model,
-        max_tokens: 1024,
+        max_tokens: 2048,
         temperature: config.temperature,
         messages: [{ role: 'user', content: prompt }],
     }

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -6,7 +6,7 @@ import { fetchRelevantHistory } from './history'
 import { logger } from './logger'
 
 const API_URL = 'https://api.anthropic.com/v1/messages'
-const DEFAULT_MODEL = 'claude-3-opus-20240229'
+const DEFAULT_MODEL = 'claude-opus-4-7'
 const DEFAULT_TEMPERATURE = 0.5
 
 const getConfig = () => ({

--- a/src/lib/components/ControlBar.svelte
+++ b/src/lib/components/ControlBar.svelte
@@ -14,7 +14,10 @@
     } = $props()
 
     const lookBackOptions = [
-        { value: '1', label: 'hour' },
+        { value: '0.25', label: '15 min' },
+        { value: '0.5', label: '30 min' },
+        { value: '0.75', label: '45 min' },
+        { value: '1', label: '1 hour' },
         { value: '2', label: '2 hours' },
         { value: '3', label: '3 hours' },
         { value: '4', label: '4 hours' },

--- a/src/lib/components/RawMessages.svelte
+++ b/src/lib/components/RawMessages.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+    import type { Message } from '$lib/types'
+
+    let { messages = [], expanded = $bindable(false) }: { messages: Message[]; expanded?: boolean } =
+        $props()
+</script>
+
+<details class="raw-messages-details" bind:open={expanded}>
+    <summary>show conversation ({messages.length} messages)</summary>
+    <div class="messages-list">
+        {#each messages as msg}
+            <div class="message-item" class:from-me={msg.sender === 'me'}>
+                <span class="sender">{msg.sender}</span>
+                <span class="text">{msg.text}</span>
+            </div>
+        {/each}
+    </div>
+</details>
+
+<style>
+    details.raw-messages-details {
+        text-align: left;
+        border: 1px solid var(--light);
+        background-color: var(--white);
+        border-radius: var(--border-radius);
+        padding: 1rem;
+        margin-bottom: 1rem;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+    }
+
+    details summary {
+        cursor: pointer;
+        font-weight: 500;
+        color: var(--primary-dark);
+    }
+
+    .messages-list {
+        margin-top: 0.75rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+    }
+
+    .message-item {
+        display: flex;
+        flex-direction: column;
+        gap: 0.15rem;
+        max-width: 85%;
+    }
+
+    .message-item.from-me {
+        align-self: flex-end;
+        align-items: flex-end;
+    }
+
+    .sender {
+        font-size: 0.75rem;
+        color: var(--gray);
+        font-family: var(--label-font);
+    }
+
+    .text {
+        font-family: var(--summary-font);
+        font-size: 0.9rem;
+        line-height: 1.4;
+        background-color: var(--light);
+        padding: 0.4rem 0.65rem;
+        border-radius: var(--border-radius);
+        color: var(--primary-dark);
+        overflow-wrap: break-word;
+    }
+
+    .from-me .text {
+        background-color: var(--primary-light);
+    }
+</style>

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -61,7 +61,7 @@ const defaultSettings: Record<string, { value?: string; description: string }> =
     },
     ANTHROPIC_MODEL: {
         value: env.ANTHROPIC_MODEL,
-        description: 'claude-3-opus-20240229 or another Anthropic model',
+        description: 'claude-opus-4-7 or another Anthropic model',
     },
     ANTHROPIC_TEMPERATURE: {
         value: env.ANTHROPIC_TEMPERATURE,
@@ -71,7 +71,7 @@ const defaultSettings: Record<string, { value?: string; description: string }> =
         value: env.GROK_API_KEY,
         description: 'Available at https://x.ai',
     },
-    GROK_MODEL: { value: env.GROK_MODEL, description: 'grok-1 or another Grok model' },
+    GROK_MODEL: { value: env.GROK_MODEL, description: 'grok-3 or another Grok model' },
     GROK_TEMPERATURE: {
         value: env.GROK_TEMPERATURE,
         description: "Controls the randomness of Grok's responses",

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -38,7 +38,7 @@ const defaultSettings: Record<string, { value?: string; description: string }> =
         value: env.OPENAI_API_KEY,
         description: 'Available at https://platform.openai.com/api-keys',
     },
-    OPENAI_MODEL: { value: env.OPENAI_MODEL, description: 'gpt-4 or any other OpenAI model' },
+    OPENAI_MODEL: { value: env.OPENAI_MODEL, description: 'gpt-4o or any other OpenAI model' },
     OPENAI_TEMPERATURE: {
         value: env.OPENAI_TEMPERATURE,
         description: 'Controls the randomness of the responses',

--- a/src/lib/grok.ts
+++ b/src/lib/grok.ts
@@ -1,7 +1,7 @@
 import { settings } from '$lib/config'
 import { fetchRelevantHistory } from './history'
 import { logger } from './logger'
-import { openAiPrompt, systemContext } from './prompts'
+import { openAiPrompt, systemContext, translatePrompt, translateSystemContext } from './prompts'
 import type { Message, ToneType } from './types'
 import { extractReplies, formatMessagesAsText, parseSummaryToHumanReadable } from './utils'
 
@@ -82,5 +82,54 @@ export const getGrokReply = async (
             summary: '',
             replies: ['(AI API error. Check your key and usage.)'],
         }
+    }
+}
+
+export const translateGrokDraft = async (
+    messages: Message[],
+    tone: ToneType,
+    userDraft: string,
+    context: string
+): Promise<{ replies: string[] }> => {
+    const config = getConfig()
+
+    if (!config.apiKey) {
+        return { replies: ['Grok API key is not configured.'] }
+    }
+
+    const body = {
+        model: config.model,
+        messages: [
+            { role: 'system', content: translateSystemContext() },
+            { role: 'user', content: formatMessagesAsText(messages) },
+            { role: 'user', content: translatePrompt(userDraft, tone, context) },
+        ],
+        temperature: config.temperature,
+        response_format: { type: 'text' },
+    }
+
+    logger.info('Sending translate request to Grok')
+
+    try {
+        const response = await fetch(API_URL, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${config.apiKey}`,
+            },
+            body: JSON.stringify(body),
+        })
+
+        if (!response.ok) {
+            throw new Error(`Grok API error code ${response.status}: ${response.statusText}`)
+        }
+
+        const data = await response.json()
+        const rawOutput = data.choices[0]?.message?.content || ''
+        const replies = extractReplies(rawOutput)
+        return { replies }
+    } catch (error) {
+        logger.error({ error }, 'Error in translateGrokDraft')
+        return { replies: ['(AI API error. Check your key and usage.)'] }
     }
 }

--- a/src/lib/grok.ts
+++ b/src/lib/grok.ts
@@ -2,7 +2,7 @@ import { settings } from '$lib/config'
 import { fetchRelevantHistory } from './history'
 import { logger } from './logger'
 import { openAiPrompt, systemContext, translatePrompt, translateSystemContext } from './prompts'
-import type { Message, ToneType } from './types'
+import type { Message, ToneType, TranslateResult } from './types'
 import { extractReplies, formatMessagesAsText, parseSummaryToHumanReadable } from './utils'
 
 const API_URL = 'https://grok.x.ai/api/chat/completions'
@@ -90,7 +90,7 @@ export const translateGrokDraft = async (
     tone: ToneType,
     userDraft: string,
     context: string
-): Promise<{ replies: string[] }> => {
+): Promise<TranslateResult> => {
     const config = getConfig()
 
     if (!config.apiKey) {

--- a/src/lib/grok.ts
+++ b/src/lib/grok.ts
@@ -6,7 +6,7 @@ import type { Message, ToneType, TranslateResult } from './types'
 import { extractReplies, formatMessagesAsText, parseSummaryToHumanReadable } from './utils'
 
 const API_URL = 'https://grok.x.ai/api/chat/completions'
-const DEFAULT_MODEL = 'grok-1'
+const DEFAULT_MODEL = 'grok-3'
 const DEFAULT_TEMPERATURE = 0.5
 
 const getConfig = () => ({

--- a/src/lib/khoj.ts
+++ b/src/lib/khoj.ts
@@ -1,5 +1,5 @@
 import { settings } from '$lib/config'
-import { khojPrompt } from '$lib/prompts'
+import { khojPrompt, translateKhojPrompt } from '$lib/prompts'
 import type { Message, ToneType } from '$lib/types'
 import { extractReplies, parseSummaryToHumanReadable } from '$lib/utils'
 import { fetchRelevantHistory } from './history'
@@ -53,5 +53,40 @@ export const getKhojReply = async (
             replies: ['(AI API error. Check your key and usage.)'],
             messageCount: messages.length,
         }
+    }
+}
+
+export const translateKhojDraft = async (
+    messages: Message[],
+    tone: ToneType,
+    userDraft: string,
+    context: string
+): Promise<{ replies: string[] }> => {
+    const prompt = translateKhojPrompt(messages, userDraft, tone, context)
+    const body = {
+        q: prompt,
+        ...(settings.KHOJ_AGENT ? { agent: settings.KHOJ_AGENT } : {}),
+    }
+
+    logger.info('Sending translate request to Khoj')
+
+    try {
+        const khojRes = await fetch(khojApiUrl, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+        })
+
+        if (!khojRes.ok) {
+            throw new Error(`Khoj API returned ${khojRes.status}`)
+        }
+
+        const data = await khojRes.json()
+        const rawOutput = data.response || ''
+        const replies = extractReplies(rawOutput)
+        return { replies }
+    } catch (err: unknown) {
+        logger.error({ error: err }, 'Error in translateKhojDraft')
+        return { replies: ['(AI API error. Check your key and usage.)'] }
     }
 }

--- a/src/lib/khoj.ts
+++ b/src/lib/khoj.ts
@@ -1,6 +1,6 @@
 import { settings } from '$lib/config'
 import { khojPrompt, translateKhojPrompt } from '$lib/prompts'
-import type { Message, ToneType } from '$lib/types'
+import type { Message, ToneType, TranslateResult } from '$lib/types'
 import { extractReplies, parseSummaryToHumanReadable } from '$lib/utils'
 import { fetchRelevantHistory } from './history'
 import { logger } from './logger'
@@ -61,7 +61,7 @@ export const translateKhojDraft = async (
     tone: ToneType,
     userDraft: string,
     context: string
-): Promise<{ replies: string[] }> => {
+): Promise<TranslateResult> => {
     const prompt = translateKhojPrompt(messages, userDraft, tone, context)
     const body = {
         q: prompt,

--- a/src/lib/openAi.ts
+++ b/src/lib/openAi.ts
@@ -1,7 +1,7 @@
 import { settings } from '$lib/config'
 import { fetchRelevantHistory } from './history'
 import { logger } from './logger'
-import { openAiPrompt, systemContext } from './prompts'
+import { openAiPrompt, systemContext, translatePrompt, translateSystemContext } from './prompts'
 import type { Message, OpenAIConfig, ToneType } from './types'
 import { extractReplies, formatMessagesAsText, parseSummaryToHumanReadable } from './utils'
 
@@ -121,5 +121,57 @@ export const getOpenaiReply = async (
             summary: '',
             replies: ['(AI API error. Check your key and usage.)'],
         }
+    }
+}
+
+export const translateOpenaiDraft = async (
+    messages: Message[],
+    tone: ToneType,
+    userDraft: string,
+    context: string
+): Promise<{ replies: string[] }> => {
+    const config = getConfig()
+
+    if (!config.apiKey) {
+        return { replies: ['OpenAI API key is not configured.'] }
+    }
+
+    const body = {
+        model: config.model,
+        messages: [
+            { role: 'system', content: translateSystemContext() },
+            { role: 'user', content: formatMessagesAsText(messages) },
+            { role: 'user', content: translatePrompt(userDraft, tone, context) },
+        ],
+        temperature: config.temperature,
+        ...(config.topP && { top_p: config.topP }),
+        ...(config.frequencyPenalty && { frequency_penalty: config.frequencyPenalty }),
+        ...(config.presencePenalty && { presence_penalty: config.presencePenalty }),
+        response_format: { type: 'text' },
+    }
+
+    logger.info('Sending translate request to OpenAI')
+
+    try {
+        const response = await fetch(API_URL, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${config.apiKey}`,
+            },
+            body: JSON.stringify(body),
+        })
+
+        if (!response.ok) {
+            throw new Error(`OpenAI API error code ${response.status}: ${response.statusText}`)
+        }
+
+        const data = await response.json()
+        const rawOutput = data.choices[0]?.message?.content || ''
+        const replies = extractReplies(rawOutput)
+        return { replies }
+    } catch (error) {
+        logger.error({ error }, 'Error in translateOpenaiDraft')
+        return { replies: ['(AI API error. Check your key and usage.)'] }
     }
 }

--- a/src/lib/openAi.ts
+++ b/src/lib/openAi.ts
@@ -6,7 +6,7 @@ import type { Message, OpenAIConfig, ToneType } from './types'
 import { extractReplies, formatMessagesAsText, parseSummaryToHumanReadable } from './utils'
 
 const API_URL = 'https://api.openai.com/v1/chat/completions'
-const DEFAULT_MODEL = 'gpt-4'
+const DEFAULT_MODEL = 'gpt-4o'
 const DEFAULT_TEMPERATURE = 0.5
 
 const getConfig = (): OpenAIConfig => ({

--- a/src/lib/openAi.ts
+++ b/src/lib/openAi.ts
@@ -2,7 +2,7 @@ import { settings } from '$lib/config'
 import { fetchRelevantHistory } from './history'
 import { logger } from './logger'
 import { openAiPrompt, systemContext, translatePrompt, translateSystemContext } from './prompts'
-import type { Message, OpenAIConfig, ToneType } from './types'
+import type { Message, OpenAIConfig, ToneType, TranslateResult } from './types'
 import { extractReplies, formatMessagesAsText, parseSummaryToHumanReadable } from './utils'
 
 const API_URL = 'https://api.openai.com/v1/chat/completions'
@@ -129,7 +129,7 @@ export const translateOpenaiDraft = async (
     tone: ToneType,
     userDraft: string,
     context: string
-): Promise<{ replies: string[] }> => {
+): Promise<TranslateResult> => {
     const config = getConfig()
 
     if (!config.apiKey) {

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -58,3 +58,48 @@ export const anthropicPrompt = (messages: Message[], tone: ToneType, context: st
         'Here are some text messages between my partner and I:\n' + formatMessagesAsText(messages),
         buildPrompt(tone, context),
     ].join('\n')
+
+const translateInstructions = [
+    'You are helping me translate a raw emotional draft into a polished, rational message.',
+    'You already know this person and this conversation from the context above.',
+    'Preserve my intent and voice. Remove reactivity. Soften sharp edges so the message lands well.',
+    'Do NOT invent new ideas — only refine what I have written.',
+].join('\n')
+
+const translateResponseFormat = [
+    'Format your response exactly as follows:',
+    '',
+    'Reply 1 (Short): [1-2 sentence version]',
+    '',
+    'Reply 2 (Medium): [3-4 sentence version]',
+    '',
+    'Reply 3 (Long): [5+ sentence version]',
+].join('\n')
+
+export const translateSystemContext = (): string =>
+    [systemContext(), translateInstructions].filter(Boolean).join('\n\n')
+
+export const translatePrompt = (userDraft: string, tone: string, context: string): string => {
+    const lines = [
+        `Here is my raw draft:\n"""\n${userDraft}\n"""`,
+        '',
+        `Rewrite this as three versions in a ${tone} tone.`,
+    ]
+    if (context) {
+        lines.push('', `Additional context: ${context}`)
+    }
+    lines.push('', translateResponseFormat)
+    return lines.join('\n')
+}
+
+export const translateKhojPrompt = (
+    messages: Message[],
+    userDraft: string,
+    tone: ToneType,
+    context: string
+): string =>
+    [
+        translateSystemContext(),
+        'Here are some text messages between my partner and I:\n' + formatMessagesAsText(messages),
+        translatePrompt(userDraft, tone, context),
+    ].join('\n')

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -26,6 +26,10 @@ export interface OpenAIChatMessage {
     content: string
 }
 
+export interface TranslateResult {
+    replies: string[]
+}
+
 export interface OpenAIConfig {
     model: string
     temperature: number

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,10 +1,10 @@
-import { getAnthropicReply } from '$lib/anthropic'
+import { getAnthropicReply, translateAnthropicDraft } from '$lib/anthropic'
 import { getAllSettings, updateSetting } from '$lib/config'
-import { getGrokReply } from '$lib/grok'
+import { getGrokReply, translateGrokDraft } from '$lib/grok'
 import { queryMessagesDb } from '$lib/iMessages'
-import { getKhojReply } from '$lib/khoj'
+import { getKhojReply, translateKhojDraft } from '$lib/khoj'
 import { logger } from '$lib/logger'
-import { getOpenaiReply } from '$lib/openAi'
+import { getOpenaiReply, translateOpenaiDraft } from '$lib/openAi'
 import { DEFAULT_PROVIDER } from '$lib/provider'
 import { getAvailableProviders, hasMultipleProviders } from '$lib/providers/registry'
 import type { Message, ToneType } from '$lib/types'
@@ -78,6 +78,47 @@ export const actions: Actions = {
 
             return fail(500, {
                 error: 'Failed to generate suggestions',
+                details: err instanceof Error ? err.message : String(err),
+            })
+        }
+    },
+    translate: async ({ request }) => {
+        try {
+            const formData = await request.formData()
+            const messagesString = formData.get('messages') as string
+            const tone = formData.get('tone') as ToneType
+            const context = formData.get('context') as string
+            const provider = formData.get('provider') as string
+            const userDraft = formData.get('userDraft') as string
+
+            if (!messagesString || !tone || !userDraft?.trim()) {
+                return fail(400, { error: 'Missing messages, tone, or draft.' })
+            }
+
+            const translateFn =
+                provider === 'khoj'
+                    ? translateKhojDraft
+                    : provider === 'anthropic'
+                      ? translateAnthropicDraft
+                      : provider === 'grok'
+                        ? translateGrokDraft
+                        : translateOpenaiDraft
+
+            let messages: Message[]
+            try {
+                messages = JSON.parse(messagesString) as Message[]
+            } catch (err) {
+                logger.error({ err }, 'Failed to parse messages for translate')
+                return fail(400, { error: 'Invalid messages format.' })
+            }
+
+            const result = await translateFn(messages, tone, userDraft, context || '')
+            logger.debug({ result }, 'Translate result')
+            return result
+        } catch (err) {
+            logger.error({ err }, 'Error translating draft')
+            return fail(500, {
+                error: 'Failed to translate draft',
                 details: err instanceof Error ? err.message : String(err),
             })
         }

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -7,7 +7,7 @@ import { logger } from '$lib/logger'
 import { getOpenaiReply, translateOpenaiDraft } from '$lib/openAi'
 import { DEFAULT_PROVIDER } from '$lib/provider'
 import { getAvailableProviders, hasMultipleProviders } from '$lib/providers/registry'
-import type { Message, ToneType } from '$lib/types'
+import { TONES, type Message, type ToneType } from '$lib/types'
 import { fail } from '@sveltejs/kit'
 import type { Actions, PageServerLoad } from './$types'
 
@@ -41,6 +41,10 @@ export const actions: Actions = {
 
             if (!messagesString || !tone) {
                 return fail(400, { error: 'Invalid request format: Missing messages or tone.' })
+            }
+
+            if (!TONES.includes(tone)) {
+                return fail(400, { error: `Invalid tone. Must be one of: ${TONES.join(', ')}.` })
             }
 
             const getReplies =
@@ -95,6 +99,10 @@ export const actions: Actions = {
                 return fail(400, { error: 'Missing messages, tone, or draft.' })
             }
 
+            if (!TONES.includes(tone)) {
+                return fail(400, { error: `Invalid tone. Must be one of: ${TONES.join(', ')}.` })
+            }
+
             const translateFn =
                 provider === 'khoj'
                     ? translateKhojDraft
@@ -110,6 +118,10 @@ export const actions: Actions = {
             } catch (err) {
                 logger.error({ err }, 'Failed to parse messages for translate')
                 return fail(400, { error: 'Invalid messages format.' })
+            }
+
+            if (!Array.isArray(messages)) {
+                return fail(400, { error: 'Invalid messages format: Expected an array of messages.' })
             }
 
             const result = await translateFn(messages, tone, userDraft, context || '')

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -14,7 +14,7 @@ import type { Actions, PageServerLoad } from './$types'
 const ONE_HOUR = 60 * 60 * 1000
 
 export const load: PageServerLoad = async ({ url }) => {
-    const lookBack = Number.parseFloat(url.searchParams.get('lookBackHours') || '1')
+    const lookBack = Math.min(Math.max(Number.parseFloat(url.searchParams.get('lookBackHours') || '1'), 0.25), 24)
     const end = new Date()
     const start = new Date(end.getTime() - lookBack * ONE_HOUR)
     const { messages } = await queryMessagesDb(start.toISOString(), end.toISOString())

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -14,7 +14,7 @@ import type { Actions, PageServerLoad } from './$types'
 const ONE_HOUR = 60 * 60 * 1000
 
 export const load: PageServerLoad = async ({ url }) => {
-    const lookBack = Number.parseInt(url.searchParams.get('lookBackHours') || '1')
+    const lookBack = Number.parseFloat(url.searchParams.get('lookBackHours') || '1')
     const end = new Date()
     const start = new Date(end.getTime() - lookBack * ONE_HOUR)
     const { messages } = await queryMessagesDb(start.toISOString(), end.toISOString())

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,6 +4,7 @@
     import AdditionalContext from '$lib/components/AdditionalContext.svelte'
     import AiProviderSelector from '$lib/components/AiProviderSelector.svelte'
     import ControlBar from '$lib/components/ControlBar.svelte'
+    import RawMessages from '$lib/components/RawMessages.svelte'
     import ReplySuggestions from '$lib/components/ReplySuggestions.svelte'
     import SettingsForm from '$lib/components/SettingsForm.svelte'
     import ToneSelector from '$lib/components/ToneSelector.svelte'
@@ -12,6 +13,7 @@
     import { type Message, type PageData, TONES, type ToneType } from '$lib/types'
 
     const LOCAL_STORAGE_CONTEXT_KEY = 'wellsaid_additional_context'
+    const LOCAL_STORAGE_DRAFT_KEY = 'wellsaid_user_draft'
 
     const { data, form } = $props<{
         data: PageData & {
@@ -31,6 +33,7 @@
         },
         ui: {
             loading: false,
+            translating: false,
         },
         form: {
             lookBackHours: '1',
@@ -39,6 +42,8 @@
             messages: [] as Message[],
             summary: '',
             suggestedReplies: [] as string[],
+            userDraft: '',
+            rawMessagesExpanded: false,
         },
     })
 
@@ -48,9 +53,16 @@
 
     // Derived values
     const hasMessages = $derived(formState.form.messages.length > 0)
-    const canGenerateReplies = $derived(hasMessages && !formState.ui.loading)
+    const canGenerateReplies = $derived(hasMessages && !formState.ui.loading && !formState.ui.translating)
     const hasProviders = $derived(data.availableProviders.length > 0)
-    const showLoadingIndicators = $derived(formState.ui.loading)
+    const hasSummary = $derived(formState.form.summary !== '')
+    const canTranslate = $derived(
+        hasSummary &&
+        formState.form.userDraft.trim().length > 0 &&
+        !formState.ui.translating &&
+        !formState.ui.loading
+    )
+    const showLoadingIndicators = $derived(formState.ui.loading || formState.ui.translating)
     const summaryContent = $derived(
         formState.ui.loading
             ? 'Generating summary and replies...'
@@ -103,6 +115,21 @@
             localStorage.setItem(LOCAL_STORAGE_CONTEXT_KEY, formState.form.additionalContext)
         } else {
             localStorage.removeItem(LOCAL_STORAGE_CONTEXT_KEY)
+        }
+    })
+
+    $effect(() => {
+        if (!browser) return
+        const storedDraft = localStorage.getItem(LOCAL_STORAGE_DRAFT_KEY)
+        if (storedDraft) formState.form.userDraft = storedDraft
+    })
+
+    $effect(() => {
+        if (!browser) return
+        if (formState.form.userDraft) {
+            localStorage.setItem(LOCAL_STORAGE_DRAFT_KEY, formState.form.userDraft)
+        } else {
+            localStorage.removeItem(LOCAL_STORAGE_DRAFT_KEY)
         }
     })
 
@@ -176,6 +203,61 @@
             formState.ui.loading = false
         }
     }
+
+    async function translateDraft() {
+        formState.ui.translating = true
+        formState.form.suggestedReplies = []
+
+        try {
+            const formData = new FormData()
+            formData.append('messages', JSON.stringify(formState.form.messages))
+            formData.append('tone', formState.form.tone)
+            formData.append('context', formState.form.additionalContext)
+            formData.append('provider', formState.ai.provider)
+            formData.append('userDraft', formState.form.userDraft)
+
+            const response = await fetch('?/translate', {
+                method: 'POST',
+                headers: { Accept: 'application/json' },
+                body: formData,
+            })
+
+            const result = await response.json()
+
+            if (!response.ok) {
+                const errorMessage = result?.error || 'Unknown error from action'
+                throw new Error(`Action failed: ${errorMessage}`)
+            }
+
+            if (result && typeof result.data === 'string') {
+                try {
+                    const parsedData = JSON.parse(result.data)
+                    // parsedData[0] = { replies: 1 }
+                    // parsedData[1] = [2, 3, 4] (indices of reply strings)
+                    // parsedData[2..4] = the actual reply strings
+                    const replyIndices = Array.isArray(parsedData[1]) ? parsedData[1] : []
+                    const replies: string[] = []
+                    for (const index of replyIndices) {
+                        if (parsedData[index] && typeof parsedData[index] === 'string') {
+                            replies.push(parsedData[index])
+                        }
+                    }
+                    formState.form.suggestedReplies = replies
+                } catch (parseError) {
+                    console.error('Error parsing translate data:', parseError)
+                    throw parseError
+                }
+            } else {
+                throw new Error('Unexpected response format from server')
+            }
+        } catch (error) {
+            formState.form.suggestedReplies = [
+                error instanceof Error ? error.message : 'Error translating draft. Please try again.',
+            ]
+        } finally {
+            formState.ui.translating = false
+        }
+    }
 </script>
 
 <svelte:head>
@@ -219,13 +301,45 @@
                         <!-- Conversation summary -->
                         <section class="conversation">
                             <div class="summary">
-                                {#if showLoadingIndicators}
+                                {#if showLoadingIndicators && !formState.ui.translating}
                                     <div class="loading-indicator">{summaryContent}</div>
                                 {:else}
                                     {summaryContent}
                                 {/if}
                             </div>
                         </section>
+
+                        <!-- Raw messages (collapsible) -->
+                        {#if hasMessages}
+                            <RawMessages
+                                messages={formState.form.messages}
+                                bind:expanded={formState.form.rawMessagesExpanded}
+                            />
+                        {/if}
+
+                        <!-- User draft + translate -->
+                        {#if hasSummary}
+                            <section class="draft-section">
+                                <label class="draft-label" for="user-draft">your draft:</label>
+                                <textarea
+                                    id="user-draft"
+                                    class="draft-input"
+                                    rows="4"
+                                    bind:value={formState.form.userDraft}
+                                    placeholder="write your raw response here — unfiltered is fine"
+                                ></textarea>
+                                <div class="translate-controls">
+                                    <button
+                                        type="button"
+                                        class="translate-button"
+                                        onclick={translateDraft}
+                                        disabled={!canTranslate}
+                                    >
+                                        {formState.ui.translating ? '...' : 'translate'}
+                                    </button>
+                                </div>
+                            </section>
+                        {/if}
 
                         <hr />
 
@@ -391,6 +505,73 @@
         color: var(--gray);
         font-style: italic;
         padding: 1rem;
+    }
+
+    /* ===== Draft & Translate ===== */
+    .draft-section {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        margin-bottom: 1rem;
+    }
+
+    .draft-label {
+        font-family: var(--label-font);
+        font-weight: 500;
+        font-size: 0.9rem;
+        color: var(--primary-dark);
+    }
+
+    .draft-input {
+        font-family: var(--label-font);
+        font-size: 1rem;
+        width: 100%;
+        padding: 0.75rem;
+        border: 1px solid var(--light);
+        border-radius: var(--border-radius);
+        resize: vertical;
+        min-height: 80px;
+        color: var(--primary-dark);
+        background-color: var(--white);
+        text-size-adjust: 100%;
+        -webkit-text-size-adjust: 100%;
+        touch-action: manipulation;
+        box-sizing: border-box;
+    }
+
+    .translate-controls {
+        display: flex;
+        justify-content: flex-end;
+    }
+
+    .translate-button {
+        background-color: var(--primary-dark);
+        color: var(--white);
+        border: 1px solid var(--light);
+        border-radius: var(--border-radius);
+        font-family: var(--body-font);
+        font-weight: 500;
+        cursor: pointer;
+        min-height: var(--min-touch-size);
+        padding: 0 1.25rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition:
+            background-color 0.2s,
+            transform 0.1s;
+    }
+
+    .translate-button:hover:not(:disabled) {
+        background-color: var(--primary-light);
+        color: var(--primary-dark);
+    }
+
+    .translate-button:disabled {
+        background-color: var(--light);
+        color: var(--gray);
+        cursor: not-allowed;
+        border-color: var(--light);
     }
 
     /* ===== Settings Styling ===== */

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -301,7 +301,7 @@
                         <!-- Conversation summary -->
                         <section class="conversation">
                             <div class="summary">
-                                {#if showLoadingIndicators && !formState.ui.translating}
+                                {#if formState.ui.loading}
                                     <div class="loading-indicator">{summaryContent}</div>
                                 {:else}
                                     {summaryContent}
@@ -329,6 +329,15 @@
                                     placeholder="write your raw response here — unfiltered is fine"
                                 ></textarea>
                                 <div class="translate-controls">
+                                    {#if formState.form.userDraft.trim()}
+                                        <button
+                                            type="button"
+                                            class="clear-draft-button"
+                                            onclick={() => (formState.form.userDraft = '')}
+                                        >
+                                            clear
+                                        </button>
+                                    {/if}
                                     <button
                                         type="button"
                                         class="translate-button"
@@ -542,6 +551,22 @@
     .translate-controls {
         display: flex;
         justify-content: flex-end;
+        gap: 0.5rem;
+    }
+
+    .clear-draft-button {
+        border: none;
+        background-color: var(--light);
+        color: var(--primary-dark);
+        border-radius: var(--border-radius);
+        padding: 0.25rem 0.75rem;
+        cursor: pointer;
+        font-family: var(--body-font);
+    }
+
+    .clear-draft-button:hover {
+        background-color: var(--primary-dark);
+        color: var(--white);
     }
 
     .translate-button {

--- a/tests/lib/providers/registry.test.ts
+++ b/tests/lib/providers/registry.test.ts
@@ -27,13 +27,13 @@ describe('provider registry', () => {
         expect(providers.every((p) => p.isAvailable)).toBe(true)
     })
 
-    it('prefers khoj as default when available', async () => {
+    it('prefers openai as default when available', async () => {
         const { settings } = await import('$lib/config')
         settings.KHOJ_API_URL = 'http://khoj.test'
         settings.OPENAI_API_KEY = 'key'
 
         const { getDefaultProvider } = await loadRegistry()
-        expect(getDefaultProvider()).toBe('khoj')
+        expect(getDefaultProvider()).toBe('openai')
     })
 
     it('throws when no providers are configured', async () => {


### PR DESCRIPTION
Two-step flow: "go" generates a conversation summary; "translate" takes the user's raw emotional draft and rewrites it as short, medium, and long polished replies informed by the conversation context and chosen tone. Also adds a collapsible raw messages viewer below the summary.