### PR TITLE
feat: add psychological profiles for partner and user

### DIFF
--- a/src/lib/components/SettingsForm.svelte
+++ b/src/lib/components/SettingsForm.svelte
@@ -30,8 +30,28 @@
         }
     })
 
+    // Textarea fields with placeholder text
+    const textareaPlaceholders: Record<string, string> = {
+        CUSTOM_CONTEXT: '',
+        PARTNER_STORY:
+            "e.g. 'I learned early that love had to be earned. I tend to believe I'm not enough unless I'm performing or achieving something.'",
+        PARTNER_TRIGGERS:
+            "e.g. 'Feeling criticized or dismissed. Sensing distance or withdrawal without explanation.'",
+        PARTNER_NEEDS:
+            "e.g. 'Reassurance that they're still valued. Patience when they go quiet — not pressure.'",
+        MY_STORY:
+            "e.g. 'I learned to be self-sufficient early on. Asking for help feels like weakness, so I often hold things in until it's too much.'",
+        MY_TRIGGERS:
+            "e.g. 'Feeling unheard or invisible. When things feel chaotic or out of my control.'",
+        MY_NEEDS:
+            "e.g. 'Space to process before talking. Knowing the relationship is stable even when things are hard.'",
+    }
+
     // Group settings by provider
     const settingsGroups = $derived({
+        profiles: settings.filter((s: { key: string; value: string; description: string }) =>
+            s.key.startsWith('PARTNER_') || s.key.startsWith('MY_')
+        ),
         general: settings.filter((s: { key: string; value: string; description: string }) =>
             ['HISTORY_LOOKBACK_HOURS', 'CONTACT_PHONE', 'CUSTOM_CONTEXT'].includes(s.key)
         ),
@@ -62,6 +82,7 @@
 
     const getSectionTitle = (section: string): string => {
         const titles: Record<string, string> = {
+            profiles: 'Profiles',
             general: 'General',
             openai: 'OpenAI',
             anthropic: 'Anthropic',
@@ -69,6 +90,11 @@
             khoj: 'Khoj',
         }
         return titles[section] || section
+    }
+
+    const sectionDescriptions: Record<string, string> = {
+        profiles:
+            'These profiles help the AI understand the emotional context beneath the conversation. Think of each field as capturing the story written in childhood — the beliefs, patterns, and needs that show up in close relationships. Leave any field blank and it will be ignored.',
     }
 
     // Auto-hide success/error messages after 3 seconds
@@ -101,6 +127,9 @@
             {/if}
             <div class="settings-section">
                 <h3 class="section-title">{getSectionTitle(section)}</h3>
+                {#if sectionDescriptions[section]}
+                    <p class="section-description">{sectionDescriptions[section]}</p>
+                {/if}
                 <div class="section-content">
                     {#each sectionSettings as setting}
                         <div class="setting-row">
@@ -108,13 +137,14 @@
                                 {formatLabel(setting.key)}
                                 <span class="description">{setting.description}</span>
                             </label>
-                            {#if setting.key === 'CUSTOM_CONTEXT'}
+                            {#if textareaPlaceholders[setting.key] !== undefined}
                                 <textarea
                                     id={setting.key}
                                     name={setting.key}
                                     bind:value={settingValues[setting.key]}
                                     rows="4"
                                     class="context-textarea"
+                                    placeholder={textareaPlaceholders[setting.key]}
                                 ></textarea>
                             {:else if rangeSettings[setting.key]}
                                 <div class="range-wrapper">
@@ -169,12 +199,19 @@
     }
 
     .section-title {
-        background: var(--primary);
-        color: var(--primary-contrast);
+        color: var(--text);
         margin: 0;
         margin-top: 1rem;
         font-size: 1rem;
         font-weight: 600;
+    }
+
+    .section-description {
+        font-size: 0.85rem;
+        color: var(--text-muted);
+        line-height: 1.5;
+        margin: 0.5rem 0 0;
+        padding: 0 0 0.25rem;
     }
 
     .section-content {
@@ -205,7 +242,7 @@
 
     input,
     textarea {
-        border: 1px solid var(--light);
+        border: 1px solid var(--border);
         border-radius: var(--border-radius);
         padding: 0.6rem 0.8rem;
         box-sizing: border-box;
@@ -213,6 +250,7 @@
         font-size: 1rem;
         width: 100%;
         color: var(--text);
+        background-color: var(--card);
         transition:
             border-color 0.2s,
             box-shadow 0.2s;
@@ -221,8 +259,8 @@
     input:focus,
     textarea:focus {
         outline: none;
-        border-color: var(--primary-dark);
-        box-shadow: 0 0 0 2px rgba(var(--primary-rgb), 0.1);
+        border-color: var(--accent);
+        box-shadow: 0 0 0 2px color-mix(in oklch, var(--accent) 20%, transparent);
     }
 
     textarea {
@@ -288,23 +326,21 @@
 
     .save {
         padding: 0.7rem 1.5rem;
-        background-color: var(--primary-dark);
-        color: var(--white);
-        border: 1px solid var(--primary-light);
-        border-radius: var(--border-radius);
+        background-color: var(--accent);
+        color: var(--accent-text);
+        border: none;
+        border-radius: 999px;
         cursor: pointer;
+        font-family: var(--body-font);
         font-weight: 500;
-        transition:
-            background-color 0.2s,
-            transform 0.1s;
+        transition: opacity 0.15s, transform 0.1s;
         min-height: var(--min-touch-size);
-        min-width: var(--min-touch-size);
         display: flex;
         align-items: center;
     }
 
     .save:hover {
-        background-color: var(--primary-dark);
+        opacity: 0.88;
     }
 
     .save:active {
@@ -312,10 +348,9 @@
     }
 
     .save:disabled {
-        background-color: var(--light);
-        color: var(--gray);
+        background-color: var(--surface);
+        color: var(--text-muted);
         cursor: not-allowed;
-        border-color: var(--light);
     }
 
     .status-message {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -78,6 +78,34 @@ const defaultSettings: Record<string, { value?: string; description: string }> =
     },
     KHOJ_API_URL: { value: env.KHOJ_API_URL, description: 'https://khoj.dev' },
     KHOJ_AGENT: { value: env.KHOJ_AGENT, description: 'optional specific agent to use' },
+    PARTNER_NAME: {
+        value: env.PARTNER_NAME,
+        description: "Your partner's preferred name",
+    },
+    PARTNER_STORY: {
+        value: env.PARTNER_STORY,
+        description: "The core belief or narrative they carry — the story their inner child wrote about their worth and safety in relationships",
+    },
+    PARTNER_TRIGGERS: {
+        value: env.PARTNER_TRIGGERS,
+        description: 'Situations or dynamics that tend to activate their core wound',
+    },
+    PARTNER_NEEDS: {
+        value: env.PARTNER_NEEDS,
+        description: 'What helps them feel safe and seen when they are activated',
+    },
+    MY_STORY: {
+        value: env.MY_STORY,
+        description: 'Your own core belief or narrative — the story your inner child wrote about your worth and safety',
+    },
+    MY_TRIGGERS: {
+        value: env.MY_TRIGGERS,
+        description: 'Situations or dynamics that tend to activate your core wound',
+    },
+    MY_NEEDS: {
+        value: env.MY_NEEDS,
+        description: 'What helps you feel safe and regulated when you are activated',
+    },
 }
 
 for (const [key, { value = '', description }] of Object.entries(defaultSettings)) {

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -2,13 +2,43 @@ import { settings } from '$lib/config'
 import type { Message, ToneType } from './types'
 import { formatMessagesAsText } from './utils'
 
-const coreContext = [
-    'You will see a conversation where messages from me are marked "me:" and messages from my partner are marked with their name.',
-    'Analyze my messages carefully to mimic my specific vocabulary, sentence structure, and communication style when suggesting replies.',
-    'Additional context about recent conversation history is provided below. Use this to understand the current situation and tone, but focus your reply on the most recent messages.',
-    'Do not summarize the history - it is only for context.',
-    'I will also provide a desired tone and may include extra context. Always incorporate both when crafting replies.',
-].join('\n')
+const getCoreContext = () => {
+    const name = settings.PARTNER_NAME || 'my partner'
+    return [
+        `You will see a conversation where messages from me are marked "me:" and messages from ${name} are marked with their name.`,
+        'Analyze my messages carefully to mimic my specific vocabulary, sentence structure, and communication style when suggesting replies.',
+        'Additional context about recent conversation history is provided below. Use this to understand the current situation and tone, but focus your reply on the most recent messages.',
+        'Do not summarize the history - it is only for context.',
+        'I will also provide a desired tone and may include extra context. Always incorporate both when crafting replies.',
+    ].join('\n')
+}
+
+const buildProfileContext = (): string => {
+    const name = settings.PARTNER_NAME || 'my partner'
+    const sections: string[] = []
+
+    const partnerParts = [
+        settings.PARTNER_STORY,
+        settings.PARTNER_TRIGGERS && `What tends to activate them: ${settings.PARTNER_TRIGGERS}`,
+        settings.PARTNER_NEEDS && `What helps them feel safe: ${settings.PARTNER_NEEDS}`,
+    ].filter(Boolean)
+
+    if (partnerParts.length > 0) {
+        sections.push(`About ${name}:\n${partnerParts.join('\n')}`)
+    }
+
+    const myParts = [
+        settings.MY_STORY,
+        settings.MY_TRIGGERS && `What tends to activate me: ${settings.MY_TRIGGERS}`,
+        settings.MY_NEEDS && `What helps me feel safe: ${settings.MY_NEEDS}`,
+    ].filter(Boolean)
+
+    if (myParts.length > 0) {
+        sections.push(`About me:\n${myParts.join('\n')}`)
+    }
+
+    return sections.join('\n\n')
+}
 
 const instructions = [
     'Given the conversation above, provide a brief summary of the current situation, emotional dynamics, and main topic.',
@@ -32,7 +62,7 @@ const responseFormat = [
 ].join('\n')
 
 export const systemContext = () =>
-    [settings.CUSTOM_CONTEXT, coreContext].filter(Boolean).join('\n\n')
+    [settings.CUSTOM_CONTEXT, buildProfileContext(), getCoreContext()].filter(Boolean).join('\n\n')
 
 const buildPrompt = (tone: string, context: string): string => {
     const lines = [`${instructions} ${tone}`]

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -24,9 +24,10 @@ export const load: PageServerLoad = async ({ url }) => {
     return {
         messages,
         multiProvider: hasMultipleProviders(),
-        defaultProvider: DEFAULT_PROVIDER || '', // Handle null case
+        defaultProvider: DEFAULT_PROVIDER || '',
         availableProviders,
         settings,
+        partnerName: settings.find((s) => s.key === 'PARTNER_NAME')?.value || '',
     }
 }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -22,6 +22,7 @@
             defaultProvider: string
             availableProviders: ProviderConfig[]
             settings: Setting[]
+            partnerName: string
         }
         form?: any
     }>()
@@ -65,10 +66,12 @@
         !formState.ui.loading
     )
     const showLoadingIndicators = $derived(formState.ui.loading || formState.ui.translating)
+    const partnerLabel = data.partnerName || 'your partner'
     const summaryContent = $derived(
         formState.ui.loading
-            ? 'Generating summary and replies...'
-            : formState.form.summary || 'click "go" to generate a conversation summary'
+            ? `Generating summary and replies...`
+            : formState.form.summary ||
+              `click "go" to generate a summary of your conversation with ${partnerLabel}`
     )
 
     // Update messages when data changes

--- a/tests/lib/prompts.test.ts
+++ b/tests/lib/prompts.test.ts
@@ -1,11 +1,14 @@
+import * as config from '$lib/config'
 import { khojPrompt, openAiPrompt, systemContext } from '$lib/prompts'
 import type { Message } from '$lib/types'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Mock configuration setting
 vi.mock('$lib/config', () => ({
     settings: { CUSTOM_CONTEXT: 'Test custom context for prompts' },
 }))
+
+const mockSettings = vi.mocked(config).settings as Record<string, string>
 
 describe('prompts', () => {
     describe('PERMANENT_CONTEXT', () => {
@@ -14,6 +17,84 @@ describe('prompts', () => {
             expect(systemContext()).toContain(
                 'mimic my specific vocabulary, sentence structure, and communication style when suggesting replies'
             )
+        })
+    })
+
+    describe('systemContext with profiles', () => {
+        beforeEach(() => {
+            // Reset all profile fields to empty between tests
+            mockSettings.CUSTOM_CONTEXT = ''
+            mockSettings.PARTNER_NAME = ''
+            mockSettings.PARTNER_STORY = ''
+            mockSettings.PARTNER_TRIGGERS = ''
+            mockSettings.PARTNER_NEEDS = ''
+            mockSettings.MY_STORY = ''
+            mockSettings.MY_TRIGGERS = ''
+            mockSettings.MY_NEEDS = ''
+        })
+
+        it('produces no profile section when all profile fields are empty', () => {
+            const result = systemContext()
+            expect(result).not.toContain('About')
+            expect(result).not.toContain('What tends to activate')
+            expect(result).not.toContain('What helps them feel safe')
+        })
+
+        it('includes partner section when PARTNER_STORY is set', () => {
+            mockSettings.PARTNER_NAME = 'Alex'
+            mockSettings.PARTNER_STORY = 'They learned early that love had to be earned.'
+            const result = systemContext()
+            expect(result).toContain('About Alex:')
+            expect(result).toContain('They learned early that love had to be earned.')
+        })
+
+        it('falls back to "my partner" when PARTNER_NAME is empty', () => {
+            mockSettings.PARTNER_STORY = 'They learned early that love had to be earned.'
+            const result = systemContext()
+            expect(result).toContain('About my partner:')
+        })
+
+        it('includes triggers and needs only when set', () => {
+            mockSettings.PARTNER_NAME = 'Alex'
+            mockSettings.PARTNER_STORY = 'Core story.'
+            mockSettings.PARTNER_TRIGGERS = 'Feeling dismissed.'
+            const result = systemContext()
+            expect(result).toContain('What tends to activate them: Feeling dismissed.')
+            expect(result).not.toContain('What helps them feel safe')
+        })
+
+        it('includes my section when MY_STORY is set', () => {
+            mockSettings.MY_STORY = 'I learned to be self-sufficient early on.'
+            const result = systemContext()
+            expect(result).toContain('About me:')
+            expect(result).toContain('I learned to be self-sufficient early on.')
+        })
+
+        it('includes both partner and my sections when both are set', () => {
+            mockSettings.PARTNER_NAME = 'Alex'
+            mockSettings.PARTNER_STORY = 'Partner story.'
+            mockSettings.MY_STORY = 'My story.'
+            const result = systemContext()
+            expect(result).toContain('About Alex:')
+            expect(result).toContain('About me:')
+        })
+
+        it('includes CUSTOM_CONTEXT before profile sections', () => {
+            mockSettings.CUSTOM_CONTEXT = 'Act as a therapist.'
+            mockSettings.PARTNER_STORY = 'Partner story.'
+            const result = systemContext()
+            expect(result.indexOf('Act as a therapist.')).toBeLessThan(result.indexOf('About'))
+        })
+
+        it('uses PARTNER_NAME in core context message labeling instruction', () => {
+            mockSettings.PARTNER_NAME = 'Jordan'
+            const result = systemContext()
+            expect(result).toContain('messages from Jordan are marked with their name')
+        })
+
+        it('falls back gracefully in core context when PARTNER_NAME is empty', () => {
+            const result = systemContext()
+            expect(result).toContain('messages from my partner are marked with their name')
         })
     })
 

--- a/tests/routes/root/server.test.ts
+++ b/tests/routes/root/server.test.ts
@@ -100,6 +100,7 @@ describe('root page server', () => {
                 },
             ],
             settings: [],
+            partnerName: '',
         })
     })
 


### PR DESCRIPTION
Surfaces attachment-aware context to the AI using Gabor Maté's framework: core belief, triggers, and needs for both the partner and the user. Profile fields are woven into the system prompt when set, and silently omitted when empty — no behavioral change for users who skip them.